### PR TITLE
feat: support no-unexpected-plugin-keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ npm i eslint-plugin-eggache --save
 
 ### no-override-exports
 
-A common mistake that newbee will make - override `module.exports` and `exports`.
+A common mistake that newbie will make - override `module.exports` and `exports`.
 
 ```js
 /* eslint eggache/no-override-exports: [ 'error' ] */
@@ -62,4 +62,25 @@ set it to `true` means to check all files.
 // ${app_root}/app.js
 module.exports = exports = {};
 exports.keys = '123456';
+```
+
+### no-unexpected-plugin-keys
+
+Sometimes, developer will confuse `plugin.js` and `config.default.js`.
+
+`plugin.js` only allow `[ 'enable', 'package', 'path', 'env' ]` and it control whether to load a plugin.
+
+The plugin's `config` should write to `config/config.{env}.js`.
+
+```js
+/* eslint eggache/no-unexpected-plugin-keys: [ 'error' ] */
+
+// config/plugin.js
+module.exports = {
+  test: {
+    enable: true,
+    package: 'egg-test',
+    someConfig: 'should not place here',
+  },
+}
 ```

--- a/index.js
+++ b/index.js
@@ -3,5 +3,6 @@
 module.exports = {
   rules: {
     'no-override-exports': require('./lib/rules/no-override-exports'),
+    'no-unexpected-plugin-keys': require('./lib/rules/no-unexpected-plugin-keys'),
   },
 };

--- a/lib/rules/no-override-exports.js
+++ b/lib/rules/no-override-exports.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const path = require('path');
+const utils = require('../utils');
 
 module.exports = {
   meta: {
@@ -17,9 +18,8 @@ module.exports = {
       },
     ],
     messages: {
-      exportsAfterModule: 'Don\'t use `exports` after `module.exports`',
-      moduleAfterExports: 'Don\'t use `module.exports` after `exports`',
-      repeatModule: 'Don\'t use `module.exports` multiple times',
+      overrideExports: 'Don\'t overide `exports`',
+      overrideModule: 'Don\'t overide `module.exports`',
     },
   },
   create(context) {
@@ -32,20 +32,20 @@ module.exports = {
     return {
       ExpressionStatement(node) {
         // only consider the root scope
-        if (context.getScope().type !== 'global') return;
+        if (!node.parent || node.parent.type !== 'Program') return;
         if (node.expression.type !== 'AssignmentExpression') return;
         const testNode = node.expression.left;
-        if (isExports(testNode)) {
+        if (utils.isExports(testNode)) {
           if (hasModule) {
-            context.report({ node, messageId: 'exportsAfterModule' });
+            context.report({ node, messageId: 'overrideExports' });
           }
           hasExports = true;
-        } else if (isModule(testNode)) {
+        } else if (utils.isModule(testNode)) {
           if (hasExports) {
-            context.report({ node, messageId: 'moduleAfterExports' });
+            context.report({ node, messageId: 'overrideExports' });
           }
           if (hasModule) {
-            context.report({ node, messageId: 'repeatModule' });
+            context.report({ node, messageId: 'overrideModule' });
           }
           hasModule = true;
         }
@@ -60,23 +60,4 @@ function isConfig(context) {
   const baseName = path.basename(filePath);
   const dirname = path.basename(path.dirname(filePath));
   return dirname === 'config' && (baseName.startsWith('config.') || baseName.startsWith('plugin.'));
-}
-
-function isExports(node) {
-  // exports.view = '';
-  // exports['view'] = '';
-  return node.object.type === 'Identifier' && node.object.name === 'exports';
-}
-
-function isModule(node) {
-  // module.exports = {};
-  // module.exports = () => {};
-  if (node.object.type === 'Identifier') {
-    return node.object.name === 'module' && node.property.type === 'Identifier' && node.property.name === 'exports';
-  }
-
-  if (node.object.type === 'MemberExpression') {
-    const realNode = node.object;
-    return realNode.object.name === 'module' && realNode.property.type === 'Identifier' && realNode.property.name === 'exports';
-  }
 }

--- a/lib/rules/no-unexpected-plugin-keys.js
+++ b/lib/rules/no-unexpected-plugin-keys.js
@@ -1,0 +1,67 @@
+'use strict';
+
+const path = require('path');
+const utils = require('../utils');
+const VALID_KEYS = [ 'enable', 'package', 'path', 'env' ];
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Disallow unexpected plugin keys in config/plugin.*.js',
+      category: 'Possible Errors',
+      recommended: true,
+      url: 'https://github.com/eggjs/eslint-plugin-eggache#no-unexpected-plugin-keys',
+    },
+    messages: {
+      unexpectedKey: 'Unexpected key: {{ key }}',
+    },
+  },
+  create(context) {
+    // only `config/plugin.*.js`
+    if (!isPlugin(context)) return {};
+
+    return {
+      ExpressionStatement(node) {
+        // only consider the root scope
+        if (!node.parent || node.parent.type !== 'Program') return;
+        if (node.expression.type !== 'AssignmentExpression') return;
+        const { left, right } = node.expression;
+
+        // only conside object, cause `exports.view = false` always valid.
+        if (utils.isExports(left) && right.type === 'ObjectExpression') {
+          checkNode(context, right);
+        }
+
+        if (utils.isModule(left) && right.type === 'ObjectExpression') {
+          for (const item of right.properties) {
+            if (item.value.type === 'ObjectExpression') {
+              checkNode(context, item.value);
+            }
+          }
+        }
+      },
+    };
+  },
+};
+
+function checkNode(context, node) {
+  for (const testNode of node.properties) {
+    if (!VALID_KEYS.includes(testNode.key.name)) {
+      context.report({
+        node: testNode,
+        messageId: 'unexpectedKey',
+        data: {
+          key: testNode.key.name,
+        },
+      });
+    }
+  }
+}
+
+function isPlugin(context) {
+  const filePath = context.getFilename();
+  if (filePath === '<input>') return true;
+  const baseName = path.basename(filePath);
+  const dirname = path.basename(path.dirname(filePath));
+  return dirname === 'config' && baseName.startsWith('plugin.');
+}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,21 @@
+'use strict';
+
+exports.isExports = function(node) {
+  // exports.view = '';
+  // exports['view'] = '';
+  return node.object.type === 'Identifier' && node.object.name === 'exports';
+};
+
+exports.isModule = function(node) {
+  // module.exports = {};
+  // module.exports = () => {};
+  if (node.object.type === 'Identifier') {
+    return node.object.name === 'module' && node.property.type === 'Identifier' && node.property.name === 'exports';
+  }
+
+  // module.exports.test = {};
+  if (node.object.type === 'MemberExpression') {
+    const realNode = node.object;
+    return realNode.object.name === 'module' && realNode.property.type === 'Identifier' && realNode.property.name === 'exports';
+  }
+};

--- a/package.json
+++ b/package.json
@@ -1,9 +1,8 @@
 {
   "name": "eslint-plugin-eggache",
   "version": "1.0.0",
-  "description": "custom eslint rule for egg RTFM questions",
+  "description": "custom eslint rule for egg RTFM issues",
   "dependencies": {
-
   },
   "devDependencies": {
     "autod": "^3.0.1",
@@ -31,7 +30,7 @@
   },
   "repository": {
     "type": "git",
-    "url": ""
+    "url": "git@github.com:eggjs/eslint-plugin-eggache.git"
   },
   "files": [
     "index.js",

--- a/test/rules/no-override-exports.test.js
+++ b/test/rules/no-override-exports.test.js
@@ -24,7 +24,6 @@ defineTest('no-override-exports', {
       `,
       // don't check not config files
       filename: '/app_root/app.js',
-      options: [ ],
     },
   ],
 
@@ -34,21 +33,21 @@ defineTest('no-override-exports', {
         exports.view = '';
         module.exports = {};
       `,
-      errors: [{ messageId: 'moduleAfterExports' }],
+      errors: [{ messageId: 'overrideExports' }],
     },
     {
       code: `
         module.exports = {};
         exports.view = '';
       `,
-      errors: [{ messageId: 'exportsAfterModule' }],
+      errors: [{ messageId: 'overrideExports' }],
     },
     {
       code: `
         module.exports = {};
         module.exports.view = '';
       `,
-      errors: [{ messageId: 'repeatModule' }],
+      errors: [{ messageId: 'overrideModule' }],
     },
     {
       code: `
@@ -58,7 +57,7 @@ defineTest('no-override-exports', {
       // check all files
       filename: '/app_root/app.js',
       options: [ true ],
-      errors: [{ messageId: 'exportsAfterModule' }],
+      errors: [{ messageId: 'overrideExports' }],
     },
   ],
 });

--- a/test/rules/no-unexpected-plugin-keys.test.js
+++ b/test/rules/no-unexpected-plugin-keys.test.js
@@ -1,0 +1,67 @@
+'use strict';
+
+const defineTest = require('../utils').defineTest;
+
+defineTest('no-unexpected-plugin-keys', {
+  valid: [
+    `
+    exports.test = {
+      enable: true,
+      package: '',
+      env: [ 'local' ],
+      path: '',
+    }
+    `,
+    `
+    module.exports = {
+      test: {
+        enable: true,
+        package: '',
+        env: [ 'local' ],
+        path: '',
+      },
+      view: false,
+    }
+    `,
+    `
+    exports.view = true;
+    module.exports.test = true;
+    `,
+    {
+      code: `
+        exports.test = {
+          enable: true,
+          package: '',
+          foo: 'bar',
+        }
+      `,
+      // don't check not plugin files
+      filename: '/config/config.default.js',
+    },
+  ],
+
+  invalid: [
+    {
+      code: `
+        exports.test = {
+          enable: true,
+          package: '',
+          foo: 'bar',
+        }
+      `,
+      errors: [{ messageId: 'unexpectedKey', data: { key: 'foo' } }],
+    },
+    {
+      code: `
+        module.exports = {
+          test: {
+            enable: true,
+            package: '',
+            other: false,
+          },
+        }
+      `,
+      errors: [{ messageId: 'unexpectedKey', data: { key: 'other' } }],
+    },
+  ],
+});

--- a/test/utils.js
+++ b/test/utils.js
@@ -2,7 +2,7 @@
 
 const is = require('is-type-of');
 const RuleTester = require('eslint').RuleTester;
-const ruleTester = new RuleTester();
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 6 } });
 
 exports.defineTest = (ruleName, fixtures) => {
   const rule = require(`../lib/rules/${ruleName}`);
@@ -19,7 +19,5 @@ function normalizeFixture(input) {
       code: input,
     };
   }
-  // input.
-  input.parserOptions = Object.assign({ ecmaVersion: 6 }, input.parserOptions);
   return input;
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
Sometimes, developer will confuse `plugin.js` and `config.default.js`.

`plugin.js` only allow `[ 'enable', 'package', 'path', 'env' ]` and it control whether to load a plugin.

The plugin's `config` should write to `config/config.{env}.js`.

```js
/* eslint eggache/no-unexpected-plugin-keys: [ 'error' ] */

// config/plugin.js
module.exports = {
  test: {
    enable: true,
    package: 'egg-test',
    someConfig: 'should not place here',
  },
}
```

https://github.com/eggjs/egg/issues/2088