### PR TITLE
feat: support no-only-tests

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,0 +1,46 @@
+# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Node.js CI
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+    branches:
+      - main
+      - master
+  schedule:
+    - cron: '0 2 * * *'
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [6, 8]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    steps:
+    - name: Checkout Git Source
+      uses: actions/checkout@v2
+
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+
+    - name: Install Dependencies
+      run: npm i -g npminstall@5 && npminstall
+
+    - name: Continuous Integration
+      run: npm run ci
+
+    - name: Code Coverage
+      uses: codecov/codecov-action@v1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -110,3 +110,16 @@ module.exports = {
   },
 }
 ```
+
+### no-only-tests
+
+A common mistake that developer will make - forget to remove `.only` in tests before committing.
+
+```js
+/* eslint eggache/no-only-tests: [ 'error' ] */
+describe.only('desc something', function() {
+  it.only('assert somnething', function() {
+    // do nothing
+  });
+})
+```

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 module.exports = {
   rules: {
+    'no-only-tests': require('./lib/rules/no-only-tests'),
     'no-override-exports': require('./lib/rules/no-override-exports'),
     'no-unexpected-plugin-keys': require('./lib/rules/no-unexpected-plugin-keys'),
   },
@@ -9,6 +10,7 @@ module.exports = {
     recommended: {
       plugins: [ 'eggache' ],
       rules: {
+        'eggache/no-only-tests': 'warn',
         'eggache/no-override-exports': 'error',
         'eggache/no-unexpected-plugin-keys': 'error',
       },

--- a/lib/rules/no-only-tests.js
+++ b/lib/rules/no-only-tests.js
@@ -1,0 +1,93 @@
+'use strict';
+
+const defaultOptions = {
+  block: [ 'describe', 'it' ],
+  focus: [ 'only' ],
+  fix: false,
+};
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'disallow .only blocks in tests',
+      category: 'Possible Errors',
+      recommended: true,
+      url: 'https://github.com/eggjs/eslint-plugin-eggache#no-only-tests',
+    },
+    fixable: true,
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          block: {
+            type: 'array',
+            items: {
+              type: 'string',
+            },
+            uniqueItems: true,
+            default: defaultOptions.block,
+          },
+          focus: {
+            type: 'array',
+            items: {
+              type: 'string',
+            },
+            uniqueItems: true,
+            default: defaultOptions.focus,
+          },
+          fix: {
+            type: 'boolean',
+            default: defaultOptions.fix,
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+  },
+  create(context) {
+    const options = Object.assign({}, defaultOptions, context.options[0]);
+    const blocks = options.block || [];
+    const focus = options.focus || [];
+    const fix = !!options.fix;
+
+    return {
+      Identifier(node) {
+        const parentObject = node.parent && node.parent.object;
+        if (parentObject == null) {
+          return;
+        }
+        if (focus.indexOf(node.name) === -1) {
+          return;
+        }
+        // 获取调用栈信息
+        const callPath = getCallPath(node.parent).join('.');
+        if (
+          blocks.find(block => {
+            if (block.endsWith('*')) return callPath.startsWith(block.replace(/\*$/, ''));
+            return callPath.startsWith(`${block}.`);
+          })
+        ) {
+          context.report({
+            node,
+            message: callPath + ' not permitted',
+            fix: fix ? fixer => fixer.removeRange([ node.range[0] - 1, node.range[1] ]) : undefined,
+          });
+        }
+      },
+    };
+  },
+};
+
+function getCallPath(node, path = []) {
+  if (node) {
+    const nodeName = node.name || (node.property && node.property.name);
+    if (node.object) {
+      return getCallPath(node.object, [ nodeName, ...path ]);
+    }
+    if (node.callee) {
+      return getCallPath(node.callee, path);
+    }
+    return [ nodeName, ...path ];
+  }
+  return path;
+}

--- a/test/rules/no-only-tests.test.js
+++ b/test/rules/no-only-tests.test.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const defineTest = require('../utils').defineTest;
+
+defineTest('no-only-tests', {
+  valid: [
+    `describe('desc something', function() {
+      // do nothing
+    });`,
+    `it("assert something", function() {
+      // do nothing
+    });`,
+  ],
+  invalid: [
+    {
+      code: `describe.only('desc something', function() {
+        // do nothing
+      })`,
+      errors: [{ message: 'describe.only not permitted' }],
+    },
+    {
+      code: `it.only('assert something', function() {
+        // do nothing
+      })`,
+      errors: [{ message: 'it.only not permitted' }],
+    },
+  ],
+});


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
导致带有 .only 的测试文件的代码默认情况下无法通过 eslint 校验

##### Description of change
默认不会禁止用户提交带有 .only 的测试文件
